### PR TITLE
Update extra_sensors_service.py

### DIFF
--- a/weewx_service/extra_sensors_service.py
+++ b/weewx_service/extra_sensors_service.py
@@ -20,7 +20,7 @@ class ExtraSensorsService(StdService):
         try:
             self.get_bmp180(event)
             self.get_dht22(event)
-        except Exception, e:
+        except Exception as e:
             syslog.syslog(syslog.LOG_ERR, "extrasensors: cannot read value: %s" % e) 
 
     # Get BMP180 data


### PR DESCRIPTION
Fix to deprecated exception syntax in Python3x